### PR TITLE
Source Trigger Type Filtering

### DIFF
--- a/DelvCD/Config/CharacterStateTrigger.cs
+++ b/DelvCD/Config/CharacterStateTrigger.cs
@@ -8,8 +8,8 @@ using ImGuiNET;
 using System;
 using System.Numerics;
 using System.Runtime.CompilerServices;
-using System.Text.Json.Serialization;
-using CharacterStruct = FFXIVClientStructs.FFXIV.Client.Game.Character.Character;
+using System.Text.Json.Serialization;using CharacterStruct = FFXIVClientStructs.FFXIV.Client.Game.Character.Character;
+
 
 namespace DelvCD.Config
 {

--- a/DelvCD/Config/StatusTrigger.cs
+++ b/DelvCD/Config/StatusTrigger.cs
@@ -87,8 +87,9 @@ namespace DelvCD.Config
             }
 
             // If the actor DOES NOT match the TriggerSourceType configured, the aura should not be triggered. We can ignore all subsequent checks.
-            // Players are always friendly, and we don't want to check TriggerSourceType if the TriggerSource is set to Player in the case TriggerSourceType is set to Enemy somehow.
-            if (this.TriggerSource is not TriggerSource.Player && !DoesActorMatchTriggerSourceType(actor, this.TriggerSourceType)) { return false; }
+            // The trigger source is not a configurable option for TriggerSource.Player so we can just skip the check if the trigger is set to that.
+            if (this.TriggerSource is not TriggerSource.Player &&
+                !DoesActorMatchTriggerSourceType(actor, this.TriggerSourceType)) { return false; }
 
             bool wasInactive = _dataSource.Status_Timer == 0;
             bool active = false;
@@ -247,16 +248,19 @@ namespace DelvCD.Config
             // Sanity check
             if (actor == null || actor is not BattleChara) { return false; }
 
+            // For Friendly character checks, this will be true. For Enemy character checks, this will be false.
             bool friendly = sourceType == TriggerSourceType.Friendly;
+
             if (actor is PlayerCharacter) { return friendly; }
 
             if (actor is BattleNpc npc) {
                 if (npc.BattleNpcKind == BattleNpcSubKind.Pet || npc.BattleNpcKind == BattleNpcSubKind.Chocobo) { return friendly; }
                 
-                return friendly == Utils.IsHostile((Character)actor);
+                // For enemy trigger checks, the 'friendly' variable will be set to false, so we want to negate that first.
+                return !friendly == Utils.IsHostile((Character)actor);
             }
 
-            // If none of the above cases are hit, then the actor and SourceType mismatch and the aura should not be triggered.
+            // If none of the above cases are hit, then the actor did not explictly match so just return false.
             return false;
         }
     }

--- a/DelvCD/Config/StatusTrigger.cs
+++ b/DelvCD/Config/StatusTrigger.cs
@@ -247,10 +247,14 @@ namespace DelvCD.Config
             // Sanity check
             if (actor == null || actor is not BattleChara) { return false; }
 
-            // Do we want to include BattleNpcSubKind.Pet or BattleNpcSubKind.Chocobo as friendly?
-            if (sourceType is TriggerSourceType.Friendly && actor is PlayerCharacter) { return true; }
+            bool friendly = sourceType == TriggerSourceType.Friendly;
+            if (actor is PlayerCharacter) { return friendly; }
 
-            if (sourceType is TriggerSourceType.Enemy && actor is BattleNpc && ((BattleNpc)actor).BattleNpcKind is BattleNpcSubKind.Enemy) { return true; }
+            if (actor is BattleNpc npc) {
+                if (npc.BattleNpcKind == BattleNpcSubKind.Pet || npc.BattleNpcKind == BattleNpcSubKind.Chocobo) { return friendly; }
+                
+                return friendly == Utils.IsHostile((Character)actor);
+            }
 
             // If none of the above cases are hit, then the actor and SourceType mismatch and the aura should not be triggered.
             return false;

--- a/DelvCD/Helpers/Enums.cs
+++ b/DelvCD/Helpers/Enums.cs
@@ -31,6 +31,12 @@ namespace DelvCD.Helpers
         FocusTarget
     }
 
+    public enum TriggerSourceType {
+        Any,
+        Friendly,
+        Enemy
+    }
+
     public enum TriggerCond
     {
         And,

--- a/DelvCD/Helpers/Utils.cs
+++ b/DelvCD/Helpers/Utils.cs
@@ -1,10 +1,12 @@
 ﻿using Dalamud.Game.ClientState.Objects;
+using Dalamud.Game.ClientState.Objects.Enums;
 using Dalamud.Game.ClientState.Objects.Types;
 using Dalamud.Plugin.Services;
 using System;
 using System.Diagnostics;
 using System.Numerics;
 using System.Runtime.InteropServices;
+using CharacterStruct = FFXIVClientStructs.FFXIV.Client.Game.Character.Character;
 
 namespace DelvCD.Helpers
 {
@@ -60,6 +62,14 @@ namespace DelvCD.Helpers
             }
 
             return null;
+        }
+
+        public static unsafe bool IsHostile(Character character)
+        {
+            CharacterStruct* chara = (CharacterStruct*)character.Address;
+            return character != null
+                && ((character.SubKind == (byte)BattleNpcSubKind.Enemy || (int)character.SubKind == (byte)BattleNpcSubKind.BattleNpcPart)
+                && chara->CharacterData.Battalion > 0);
         }
 
         public static bool GetResult(

--- a/DelvCD/Helpers/Utils.cs
+++ b/DelvCD/Helpers/Utils.cs
@@ -64,12 +64,18 @@ namespace DelvCD.Helpers
             return null;
         }
 
+        /// <summary>
+        /// Checks if a character is considered hostile relative to the player.
+        /// </summary>
+        /// <param name="character">The <c>Character</c> object to check.</param>
+        /// <returns>Returns true if <c>Character</c> provided is hostile, otherwise false.</returns>
         public static unsafe bool IsHostile(Character character)
         {
             CharacterStruct* chara = (CharacterStruct*)character.Address;
+
             return character != null
                 && ((character.SubKind == (byte)BattleNpcSubKind.Enemy || (int)character.SubKind == (byte)BattleNpcSubKind.BattleNpcPart)
-                && chara->CharacterData.Battalion > 0);
+                && chara->CharacterData.Battalion > 0); // Since its not super clear, CharacterData.Battalion used for determining friend/enemy state
         }
 
         public static bool GetResult(


### PR DESCRIPTION
Added functionality to StatusTriggers to check if TriggerSource is an enemy or friendly GameObject and only trigger aura if the option is selected.

As a healer main, I used XIVAuras to track when I didn't have a DoT on the boss. In the current version of DelvCD, my "DoT is missing" aura activates on friendly players. I've added functionality to filter aura triggering based on if its an enemy, friendly character, or any of those (which is the current behavior).


I originally attempted to add this [a while ago](https://github.com/lichie567/XIVAuras/pull/37) but the original author never got back to me. 

Video of functionality:


https://github.com/DelvUI/DelvCD/assets/908648/fbfefd21-67fe-4efb-9b17-848f54293320

