### PR TITLE
feat: adds dynamic group positioning

### DIFF
--- a/DelvCD/Config/GroupConfig.cs
+++ b/DelvCD/Config/GroupConfig.cs
@@ -12,6 +12,8 @@ namespace DelvCD.Config
         [JsonIgnore] private static Vector2 _screenSize = ImGui.GetMainViewport().Size;
 
         public string Name => "Group";
+        public bool Dynamic = false;
+        public Vector2 DynamicOffset = new Vector2(0, 0);
 
         public Vector2 Position = new Vector2(0, 0);
 
@@ -29,6 +31,12 @@ namespace DelvCD.Config
             if (ImGui.BeginChild("##GroupConfig", new Vector2(size.X, size.Y), true))
             {
                 ImGui.DragFloat2("Group Position", ref Position);
+
+                ImGui.NewLine();
+                ImGui.Checkbox("Dynamic Grouping", ref Dynamic);
+                if (Dynamic) {
+                  ImGui.DragFloat2("Dynamic Offset", ref DynamicOffset);
+                }
 
                 ImGui.NewLine();
                 ImGui.Text("Resize Icons");

--- a/DelvCD/Config/GroupConfig.cs
+++ b/DelvCD/Config/GroupConfig.cs
@@ -12,7 +12,7 @@ namespace DelvCD.Config
         [JsonIgnore] private static Vector2 _screenSize = ImGui.GetMainViewport().Size;
 
         public string Name => "Group";
-        public bool Dynamic = false;
+        public bool IsDynamic = false;
         public Vector2 DynamicOffset = new Vector2(0, 0);
 
         public Vector2 Position = new Vector2(0, 0);
@@ -33,9 +33,10 @@ namespace DelvCD.Config
                 ImGui.DragFloat2("Group Position", ref Position);
 
                 ImGui.NewLine();
-                ImGui.Checkbox("Dynamic Grouping", ref Dynamic);
-                if (Dynamic) {
-                  ImGui.DragFloat2("Dynamic Offset", ref DynamicOffset);
+                ImGui.Checkbox("Dynamic Grouping", ref IsDynamic);
+                
+                if (IsDynamic) {
+                    ImGui.DragFloat2("Dynamic Offset", ref DynamicOffset);
                 }
 
                 ImGui.NewLine();

--- a/DelvCD/DelvCD.csproj
+++ b/DelvCD/DelvCD.csproj
@@ -46,6 +46,11 @@
         <DalamudLibPath>$(APPDATA)\XIVLauncher\addon\Hooks\$(DalamudVersion)\</DalamudLibPath>
     </PropertyGroup>
 
+    <!-- Dalamud Configuration (Linux-specific) -->
+    <PropertyGroup Condition=" $([MSBuild]::IsOSPlatform('Linux')) ">
+        <DalamudLibPath>$([System.IO.Path]::GetFullPath('$(HOME)/.xlcore/dalamud/Hooks/$(DalamudVersion)/'))</DalamudLibPath>
+    </PropertyGroup>
+
     <!-- Assembly Reference Locations -->
     <PropertyGroup>
         <AssemblySearchPaths>

--- a/DelvCD/UIElements/Group.cs
+++ b/DelvCD/UIElements/Group.cs
@@ -62,6 +62,7 @@ namespace DelvCD.UIElements
         {
             bool visible = VisibilityConfig.IsVisible(parentVisible);
             int index = 0;
+            
             foreach (UIElement element in ElementList.UIElements)
             {
                 if (!Preview && LastFrameWasPreview)
@@ -75,19 +76,11 @@ namespace DelvCD.UIElements
 
                 if (visible || Singletons.Get<PluginManager>().IsConfigOpen())
                 {
-                    if (GroupConfig.Dynamic)
-                    {
-                        float groupX = GroupConfig.Position.X + (index * GroupConfig.DynamicOffset.X);
-                        float groupY = GroupConfig.Position.Y + (index * GroupConfig.DynamicOffset.Y);
+                    Vector2 offset = GroupConfig.IsDynamic ? index * GroupConfig.DynamicOffset : Vector2.Zero;
 
-                        Vector2 groupWithOffset = new Vector2(groupX, groupY);
+                    element.Draw(pos + GroupConfig.Position + offset, null, visible);
 
-                        index++;
-
-                        element.Draw(pos + groupWithOffset, null, visible);
-                    } else {
-                        element.Draw(pos + GroupConfig.Position, null, visible);
-                    }
+                    index++;
                 }
             }
 

--- a/DelvCD/UIElements/Group.cs
+++ b/DelvCD/UIElements/Group.cs
@@ -61,6 +61,7 @@ namespace DelvCD.UIElements
         public override void Draw(Vector2 pos, Vector2? parentSize = null, bool parentVisible = true)
         {
             bool visible = VisibilityConfig.IsVisible(parentVisible);
+            int index = 0;
             foreach (UIElement element in ElementList.UIElements)
             {
                 if (!Preview && LastFrameWasPreview)
@@ -74,7 +75,19 @@ namespace DelvCD.UIElements
 
                 if (visible || Singletons.Get<PluginManager>().IsConfigOpen())
                 {
-                    element.Draw(pos + GroupConfig.Position, null, visible);
+                    if (GroupConfig.Dynamic)
+                    {
+                        float groupX = GroupConfig.Position.X + (index * GroupConfig.DynamicOffset.X);
+                        float groupY = GroupConfig.Position.Y + (index * GroupConfig.DynamicOffset.Y);
+
+                        Vector2 groupWithOffset = new Vector2(groupX, groupY);
+
+                        index++;
+
+                        element.Draw(pos + groupWithOffset, null, visible);
+                    } else {
+                        element.Draw(pos + GroupConfig.Position, null, visible);
+                    }
                 }
             }
 


### PR DESCRIPTION
This PR adds:
- a dynamic grouping toggle and offset slider to the group element. It will check for the Dynamic bool and render its children in accordance to its index and the proposed offset. This is a similar feel to how weakauras achieves this.
- a cheeky line of code to allow development on Linux

This also should be backwards compatible, but testing may be required. 

Note:
Developing on Linux and so I don't have access to linting/tools in Visual Studio. Let me know if there are style changes required. I'm also not a C# developer, so criticism expected!