### PR TITLE
Prevent root window from taking focus when appearing

### DIFF
--- a/DelvCD/PluginManager.cs
+++ b/DelvCD/PluginManager.cs
@@ -35,7 +35,8 @@ namespace DelvCD
             ImGuiWindowFlags.AlwaysAutoResize |
             ImGuiWindowFlags.NoBackground |
             ImGuiWindowFlags.NoInputs |
-            ImGuiWindowFlags.NoBringToFrontOnFocus;
+            ImGuiWindowFlags.NoBringToFrontOnFocus |
+            ImGuiWindowFlags.NoFocusOnAppearing;
 
         public PluginManager(
             IClientState clientState,


### PR DESCRIPTION
Simply adds the `ImGuiWindowFlags.NoFocusOnAppearing` flag to the `DelvCD_Root` window. Without this flag, the overlay root appearing can cause an active input box to lose focus or cause a plugin like Wotsit to close due to loss of focus. This is likely to happen after zoning, for example, because the window is temporarily hidden during that time. Since this is an overlay window which doesn't actually need focus, I don't think there's any downside to setting this flag.