### PR TITLE
Update the timer if the duration is higher than previous max duration

### DIFF
--- a/DelvCD/Config/StatusTrigger.cs
+++ b/DelvCD/Config/StatusTrigger.cs
@@ -122,7 +122,7 @@ namespace DelvCD.Config
 
                         _dataSource.Name = trigger.Name;
 
-                        if (wasInactive)
+                        if (wasInactive || _dataSource.Max_Status_Timer < _dataSource.Status_Timer)
                         {
                             _dataSource.Max_Status_Timer = _dataSource.Status_Timer;
                         }


### PR DESCRIPTION
Fixes debuffs that add onto a duration rather than setting it to it's max.
This should fix abilities lik Death's Design, Noxious Gnash, The Warriors Buff etc

Before:

https://github.com/DelvUI/DelvCD/assets/4972345/6cc9f529-7263-4214-a3b7-2a3a27f84271



After:
https://github.com/DelvUI/DelvCD/assets/4972345/a9c02c64-c468-4e67-a522-86d0095a8c9b

