### PR TITLE
Add Value field on datasource to fix default labels

### DIFF
--- a/DelvCD/Config/CooldownTrigger.cs
+++ b/DelvCD/Config/CooldownTrigger.cs
@@ -127,6 +127,7 @@ namespace DelvCD.Config
 
             _dataSource.Id = actionId;
             _dataSource.Cooldown_Timer = cooldown;
+            _dataSource.Value = cooldown;
             _dataSource.Max_Cooldown_Timer = chargeTime;
             _dataSource.Cooldown_Stacks = stacks;
             _dataSource.Max_Cooldown_Stacks = recastInfo.MaxCharges;

--- a/DelvCD/Config/StatusTrigger.cs
+++ b/DelvCD/Config/StatusTrigger.cs
@@ -109,6 +109,7 @@ namespace DelvCD.Config
                         active = true;
                         _dataSource.Id = status.StatusId;
                         _dataSource.Status_Timer = Math.Abs(status.RemainingTime);
+                        _dataSource.Value = Math.Abs(status.RemainingTime);
                         _dataSource.Status_Stacks = status.StackCount;
                         _dataSource.Max_Status_Stacks = trigger.MaxStacks;
 

--- a/DelvCD/Helpers/DataSources/DataSource.cs
+++ b/DelvCD/Helpers/DataSources/DataSource.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Reflection;
+﻿using System.Collections.Generic;
 
 namespace DelvCD.Helpers.DataSources
 {
@@ -14,7 +11,7 @@ namespace DelvCD.Helpers.DataSources
 
         public float PreviewValue;
         public float PreviewMaxValue => 100;
-
+        public float Value;
 
         // condition fields
         protected List<string> _conditionFieldNames = new();

--- a/DelvCD/UIElements/Icon.cs
+++ b/DelvCD/UIElements/Icon.cs
@@ -322,14 +322,18 @@ namespace DelvCD.UIElements
             IconStyleConfig.Position *= scaleFactor;
 
             if (!positionOnly)
+            {
                 IconStyleConfig.Size *= scaleFactor;
+            }
 
             foreach (var condition in StyleConditions.Conditions)
             {
                 condition.Style.Position *= scaleFactor;
 
                 if (!positionOnly)
+                {
                     condition.Style.Size *= scaleFactor;
+                }
             }
         }
 


### PR DESCRIPTION
This fixes the default labels [value:t] which will be a valid tag for the most common triggers (cooldown and status)