### PR TITLE
Fix monk master chakra gauge options

### DIFF
--- a/DelvCD/Config/JobGauges/MonkJobGauge.cs
+++ b/DelvCD/Config/JobGauges/MonkJobGauge.cs
@@ -24,9 +24,9 @@ namespace DelvCD.Config.JobGauges
         {
             _names = new List<string>() {
                 "Chakra Stacks",
-                "Master's Gauge Chakra #1",
-                "Master's Gauge Chakra #2",
-                "Master's Gauge Chakra #3",
+                "Master's Gauge Opo-opo Count",
+                "Master's Gauge Raptor Count",
+                "Master's Gauge Coeurl Count",
                 "Solar Nadi",
                 "Lunar Nadi",
                 "Blitz Timer",
@@ -37,23 +37,15 @@ namespace DelvCD.Config.JobGauges
 
             _types = new List<TriggerConditionType>() {
                 TriggerConditionType.Numeric,
-                TriggerConditionType.Combo,
-                TriggerConditionType.Combo,
-                TriggerConditionType.Combo,
+                TriggerConditionType.Numeric,
+                TriggerConditionType.Numeric,
+                TriggerConditionType.Numeric,
                 TriggerConditionType.Boolean,
                 TriggerConditionType.Boolean,
                 TriggerConditionType.Numeric,
                 TriggerConditionType.Numeric,
                 TriggerConditionType.Numeric,
                 TriggerConditionType.Numeric
-            };
-
-            string[] chakras = new string[] { "None", "Coeurl", "Opo-opo", "Raptor" };
-            _comboOptions = new Dictionary<int, string[]>()
-            {
-                [1] = chakras,
-                [2] = chakras,
-                [3] = chakras,
             };
         }
 
@@ -62,9 +54,26 @@ namespace DelvCD.Config.JobGauges
             MNKGauge gauge = Singletons.Get<IJobGauges>().Get<MNKGauge>();
 
             _dataSource.Chakra_Stacks = gauge.Chakra;
-            _dataSource.Masters_Gauge_Chakra_1 = _comboOptions[1][_values[1]];
-            _dataSource.Masters_Gauge_Chakra_2 = _comboOptions[2][_values[2]];
-            _dataSource.Masters_Gauge_Chakra_3 = _comboOptions[3][_values[3]];
+
+            _dataSource.Masters_Gauge_Opo_Count = 0;
+            _dataSource.Masters_Gauge_Raptor_Count = 0;
+            _dataSource.Masters_Gauge_Coeurl_Count = 0;
+            foreach (var chakra in gauge.BeastChakra)
+            {
+                switch (chakra)
+                {
+                    case BeastChakra.OPOOPO:
+                        _dataSource.Masters_Gauge_Opo_Count++;
+                        break;
+                    case BeastChakra.RAPTOR:
+                        _dataSource.Masters_Gauge_Raptor_Count++;
+                        break;
+                    case BeastChakra.COEURL:
+                        _dataSource.Masters_Gauge_Coeurl_Count++;
+                        break;
+                }
+            }
+
             _dataSource.Solar_Nadi = (gauge.Nadi & Nadi.SOLAR) != 0;
             _dataSource.Lunar_Nadi = (gauge.Nadi & Nadi.LUNAR) != 0;
             _dataSource.Blitz_Timer = gauge.BlitzTimeRemaining / 1000f;
@@ -79,22 +88,15 @@ namespace DelvCD.Config.JobGauges
 
             return
                 EvaluateCondition(0, _dataSource.Chakra_Stacks) &&
-                EvaluateMastersGaugeChakraCondition(gauge, 0) &&
-                EvaluateMastersGaugeChakraCondition(gauge, 1) &&
-                EvaluateMastersGaugeChakraCondition(gauge, 2) &&
+                EvaluateCondition(1, _dataSource.Masters_Gauge_Opo_Count) &&
+                EvaluateCondition(2, _dataSource.Masters_Gauge_Raptor_Count) &&
+                EvaluateCondition(3, _dataSource.Masters_Gauge_Coeurl_Count) &&
                 EvaluateCondition(4, _dataSource.Solar_Nadi) &&
                 EvaluateCondition(5, _dataSource.Lunar_Nadi) &&
                 EvaluateCondition(6, _dataSource.Blitz_Timer) &&
                 EvaluateCondition(7, _dataSource.Opoopo_Stacks) &&
                 EvaluateCondition(8, _dataSource.Raptor_Stacks) &&
                 EvaluateCondition(9, _dataSource.Coeurl_Stacks);
-        }
-
-        private bool EvaluateMastersGaugeChakraCondition(MNKGauge gauge, int chakra)
-        {
-            if (!ConditionEnabledforIndex(1 + chakra)) { return true; }
-
-            return (int)gauge.BeastChakra[chakra] == _values[1 + chakra];
         }
     }
 }

--- a/DelvCD/Helpers/DataSources/JobDataSources/MonkDataSource.cs
+++ b/DelvCD/Helpers/DataSources/JobDataSources/MonkDataSource.cs
@@ -6,9 +6,9 @@
 
         public int Chakra_Stacks;
         public int Max_Chakra_Stacks;
-        public string Masters_Gauge_Chakra_1 = string.Empty;
-        public string Masters_Gauge_Chakra_2 = string.Empty;
-        public string Masters_Gauge_Chakra_3 = string.Empty;
+        public int Masters_Gauge_Opo_Count;
+        public int Masters_Gauge_Raptor_Count;
+        public int Masters_Gauge_Coeurl_Count;
         public bool Solar_Nadi;
         public bool Lunar_Nadi;
         public float Blitz_Timer;
@@ -24,6 +24,9 @@
             3 => Opoopo_Stacks,
             4 => Raptor_Stacks,
             5 => Coeurl_Stacks,
+            6 => Masters_Gauge_Opo_Count,
+            7 => Masters_Gauge_Raptor_Count,
+            8 => Masters_Gauge_Coeurl_Count,
             _ => 0
         };
 
@@ -34,6 +37,9 @@
             2 => Opoopo_Stacks,
             3 => Raptor_Stacks,
             4 => Coeurl_Stacks,
+            5 => Masters_Gauge_Opo_Count,
+            6 => Masters_Gauge_Raptor_Count,
+            7 => Masters_Gauge_Coeurl_Count,
             _ => 0
         };
 
@@ -44,6 +50,9 @@
             2 => 1,
             3 => 1,
             4 => 2,
+            5 => 3,
+            6 => 3,
+            7 => 3,
             _ => 0
         };
 
@@ -56,6 +65,9 @@
                 nameof(Opoopo_Stacks),
                 nameof(Raptor_Stacks),
                 nameof(Coeurl_Stacks),
+                nameof(Masters_Gauge_Opo_Count),
+                nameof(Masters_Gauge_Raptor_Count),
+                nameof(Masters_Gauge_Coeurl_Count),
             };
 
             _progressFieldNames = new() {
@@ -64,6 +76,9 @@
                 nameof(Opoopo_Stacks),
                 nameof(Raptor_Stacks),
                 nameof(Coeurl_Stacks),
+                nameof(Masters_Gauge_Opo_Count),
+                nameof(Masters_Gauge_Raptor_Count),
+                nameof(Masters_Gauge_Coeurl_Count),
             };
         }
     }


### PR DESCRIPTION
Changing the way the Monk master's chakra gauge works. The existing options don't make sense for any use case because the order of the chakra does not matter, only the number of each type present matters. Its much easier to use these if they are treated like a numeric data source.