### PR TITLE
Implement basic keybind Labels

### DIFF
--- a/DelvCD/Config/CooldownTrigger.cs
+++ b/DelvCD/Config/CooldownTrigger.cs
@@ -143,6 +143,15 @@ namespace DelvCD.Config
             _dataSource.Max_Cooldown_Stacks = recastInfo.MaxCharges;
             _dataSource.Icon = Adjust ? helper.GetIconIdForAction(actionId) : actionTrigger.Icon;
             _dataSource.Name = Adjust ? helper.GetAdjustedActionName(actionId) : actionTrigger.Name;
+            
+            
+            KeybindHelper keybindHelper = Singletons.Get<KeybindHelper>();
+            // TODO: Needs to be moved to some place/event that only gets triggered on either job swap or when someone updates their hotbar
+            // AgentUpdateFlags ActionBarUpdate is no good because that will trigger by using actions as well apparently
+            keybindHelper.UpdateKeybindHints();
+            
+            _dataSource.Keybind = keybindHelper.GetKeybindHint(actionTrigger.Id, KeybindHelper.KeybindType.Action);
+            _dataSource.Keybind_Formatted = keybindHelper.GetKeybindHintFormatted(actionTrigger.Id, KeybindHelper.KeybindType.Action);
 
             return
                 (!Combo || (ComboValue == 0 ? comboActive : !comboActive)) &&

--- a/DelvCD/Config/CooldownTrigger.cs
+++ b/DelvCD/Config/CooldownTrigger.cs
@@ -146,10 +146,6 @@ namespace DelvCD.Config
             
             
             KeybindHelper keybindHelper = Singletons.Get<KeybindHelper>();
-            // TODO: Needs to be moved to some place/event that only gets triggered on either job swap or when someone updates their hotbar
-            // AgentUpdateFlags ActionBarUpdate is no good because that will trigger by using actions as well apparently
-            keybindHelper.UpdateKeybindHints();
-            
             _dataSource.Keybind = keybindHelper.GetKeybindHint(actionTrigger.Id, KeybindHelper.KeybindType.Action);
             _dataSource.Keybind_Formatted = keybindHelper.GetKeybindHintFormatted(actionTrigger.Id, KeybindHelper.KeybindType.Action);
 

--- a/DelvCD/Config/ItemCooldownTrigger.cs
+++ b/DelvCD/Config/ItemCooldownTrigger.cs
@@ -58,6 +58,14 @@ namespace DelvCD.Config
 
             _dataSource.Item_Cooldown_Stacks = GetQuantity(actionTrigger.Id);
             _dataSource.Max_Item_Cooldown_Stacks = _dataSource.Item_Cooldown_Stacks;
+            
+            KeybindHelper keybindHelper = Singletons.Get<KeybindHelper>();
+            // TODO: Needs to be moved to some place/event that only gets triggered on either job swap or when someone updates their hotbar
+            // AgentUpdateFlags ActionBarUpdate is no good because that will trigger by using actions as well apparently
+            keybindHelper.UpdateKeybindHints();
+            
+            _dataSource.Item_Keybind = keybindHelper.GetKeybindHint(actionTrigger.Id, KeybindHelper.KeybindType.Item);
+            _dataSource.Item_Keybind_Formatted = keybindHelper.GetKeybindHintFormatted(actionTrigger.Id, KeybindHelper.KeybindType.Item);
 
             return !Cooldown || Utils.GetResult(_dataSource.Item_Cooldown_Timer, CooldownOp, CooldownValue);
         }

--- a/DelvCD/Config/ItemCooldownTrigger.cs
+++ b/DelvCD/Config/ItemCooldownTrigger.cs
@@ -60,10 +60,6 @@ namespace DelvCD.Config
             _dataSource.Max_Item_Cooldown_Stacks = _dataSource.Item_Cooldown_Stacks;
             
             KeybindHelper keybindHelper = Singletons.Get<KeybindHelper>();
-            // TODO: Needs to be moved to some place/event that only gets triggered on either job swap or when someone updates their hotbar
-            // AgentUpdateFlags ActionBarUpdate is no good because that will trigger by using actions as well apparently
-            keybindHelper.UpdateKeybindHints();
-            
             _dataSource.Item_Keybind = keybindHelper.GetKeybindHint(actionTrigger.Id, KeybindHelper.KeybindType.Item);
             _dataSource.Item_Keybind_Formatted = keybindHelper.GetKeybindHintFormatted(actionTrigger.Id, KeybindHelper.KeybindType.Item);
 

--- a/DelvCD/Helpers/DataSources/CooldownDataSource.cs
+++ b/DelvCD/Helpers/DataSources/CooldownDataSource.cs
@@ -9,6 +9,8 @@
         public float Max_Cooldown_Timer;
         public int Cooldown_Stacks;
         public int Max_Cooldown_Stacks;
+        public string? Keybind = string.Empty;
+        public string? Keybind_Formatted = string.Empty;
 
         public override float GetConditionValue(int index) => index switch
         {

--- a/DelvCD/Helpers/DataSources/ItemCooldownDataSource.cs
+++ b/DelvCD/Helpers/DataSources/ItemCooldownDataSource.cs
@@ -8,6 +8,8 @@
         public float Max_Item_Cooldown_Timer;
         public int Item_Cooldown_Stacks;
         public int Max_Item_Cooldown_Stacks;
+        public string? Item_Keybind = string.Empty;
+        public string? Item_Keybind_Formatted = string.Empty;
 
         public override float GetConditionValue(int index) => index switch
         {

--- a/DelvCD/Helpers/KeybindHelper.cs
+++ b/DelvCD/Helpers/KeybindHelper.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
@@ -40,6 +40,7 @@ public unsafe class KeybindHelper
             return;
         }
 
+        Singletons.Get<IClientState>().ClassJobChanged -= OnJobChanged;
         Instance = null!;
     }
     

--- a/DelvCD/Helpers/KeybindHelper.cs
+++ b/DelvCD/Helpers/KeybindHelper.cs
@@ -7,7 +7,6 @@ using FFXIVClientStructs.Attributes;
 using FFXIVClientStructs.FFXIV.Client.Game;
 using FFXIVClientStructs.FFXIV.Client.UI;
 using FFXIVClientStructs.FFXIV.Client.UI.Misc;
-using Lumina.Data.Parsing;
 
 namespace DelvCD.Helpers;
 
@@ -88,13 +87,6 @@ public unsafe class KeybindHelper
 
         foreach (var addonName in _actionBars) {
             string? nameToUse = addonName;
-        
-            if (string.IsNullOrEmpty(addonName)) {
-                var attr = (Addon)typeof(AddonActionBarX).GetCustomAttribute(typeof(Addon))!;
-                if (attr != null) {
-                    nameToUse = attr.AddonIdentifiers.FirstOrDefault();
-                }
-            }
 
             AddonActionBarX* addon = !string.IsNullOrEmpty(nameToUse) 
                 ? (AddonActionBarX*)gameGui.GetAddonByName(nameToUse, 1) 

--- a/DelvCD/Helpers/KeybindHelper.cs
+++ b/DelvCD/Helpers/KeybindHelper.cs
@@ -19,6 +19,7 @@ public unsafe class KeybindHelper
     
     public KeybindHelper()
     {
+        Singletons.Get<IClientState>().ClassJobChanged += OnJobChanged;
     }
 
     public static void Initialize() { Instance = new KeybindHelper(); }
@@ -126,6 +127,12 @@ public unsafe class KeybindHelper
         keybindHint = keybindHint.Replace("ª", "a");      // Alt
         keybindHint = keybindHint.Replace("º", "n");      // Numpad
         return keybindHint;
+    }
+    
+    private void OnJobChanged(uint _)
+    {
+        // Update the action bar when the job changes
+        UpdateKeybindHints();
     }
     
     public uint StripFirstTwoDigits(uint number)

--- a/DelvCD/Helpers/KeybindHelper.cs
+++ b/DelvCD/Helpers/KeybindHelper.cs
@@ -1,0 +1,142 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using Dalamud.Plugin.Services;
+using FFXIVClientStructs.Attributes;
+using FFXIVClientStructs.FFXIV.Client.Game;
+using FFXIVClientStructs.FFXIV.Client.UI;
+using FFXIVClientStructs.FFXIV.Client.UI.Misc;
+using Lumina.Data.Parsing;
+
+namespace DelvCD.Helpers;
+
+public unsafe class KeybindHelper
+{
+    // Referenced https://github.com/Caraxi/SimpleTweaksPlugin/blob/main/Tweaks/UiAdjustment/ControlHintMirroring.cs for a lot of this code.
+    
+    #region Singleton
+    
+    public KeybindHelper()
+    {
+    }
+
+    public static void Initialize() { Instance = new KeybindHelper(); }
+
+    public static KeybindHelper Instance { get; private set; } = null!;
+
+    ~KeybindHelper() { Dispose(false); }
+
+    public void Dispose()
+    {
+        Dispose(true);
+        GC.SuppressFinalize(this);
+    }
+
+    protected void Dispose(bool disposing)
+    {
+        if (!disposing)
+        {
+            return;
+        }
+
+        Instance = null!;
+    }
+    
+    #endregion
+    
+    private readonly Dictionary<uint, string> _keybindActionHints = new();
+    private readonly Dictionary<uint, string> _keybindItemHints = new();
+    private readonly string?[] _actionBars = ["_ActionBar09", "_ActionBar", "_ActionBar01", "_ActionBar02", "_ActionBar03", "_ActionBar04", "_ActionBar05", "_ActionBar06", "_ActionBar07", "_ActionBar08"];
+    
+    private void ActionBarUpdateRequested(AddonActionBarX* addon) {
+        var barId = addon->AddonActionBarBase.RaptureHotbarId;
+        if (barId == 9)
+        {
+            _keybindActionHints.Clear(); // Relies on the game updating action bars in reverse order
+            _keybindItemHints.Clear(); // Relies on the game updating action bars in reverse order
+        }
+
+        for (var slotIndex = (byte)(addon->AddonActionBarBase.SlotCount - 1); slotIndex < addon->AddonActionBarBase.SlotCount; slotIndex--) {
+            var slot = RaptureHotbarModule.Instance()->GetSlotById(barId, slotIndex);
+            if (slot->CommandType == RaptureHotbarModule.HotbarSlotType.Empty)
+            {
+                continue;
+            }
+
+            var str = slot->KeybindHintString;
+            if (string.IsNullOrWhiteSpace(str)) {
+                continue;
+            }
+
+            if (slot->CommandType == RaptureHotbarModule.HotbarSlotType.Item)
+            {
+                // For some reason the first 2 digits for items (well or some items) is 10?
+                var itemId = StripFirstTwoDigits(slot->CommandId);
+                _keybindItemHints[itemId] = str;
+                continue;
+            }
+            
+            var actionId = ActionManager.Instance()->GetAdjustedActionId(slot->CommandId);
+            _keybindActionHints[actionId] = str;
+        }
+    }
+    
+    public void UpdateKeybindHints() {
+        var gameGui = Singletons.Get<IGameGui>();
+
+        foreach (var addonName in _actionBars) {
+            string? nameToUse = addonName;
+        
+            if (string.IsNullOrEmpty(addonName)) {
+                var attr = (Addon)typeof(AddonActionBarX).GetCustomAttribute(typeof(Addon))!;
+                if (attr != null) {
+                    nameToUse = attr.AddonIdentifiers.FirstOrDefault();
+                }
+            }
+
+            AddonActionBarX* addon = !string.IsNullOrEmpty(nameToUse) 
+                ? (AddonActionBarX*)gameGui.GetAddonByName(nameToUse, 1) 
+                : null;
+
+            if (addon != null) {
+                ActionBarUpdateRequested(addon);
+            }
+        }
+    }
+
+    public string GetKeybindHint(uint id, KeybindType type)
+    {
+        var dictionary = type switch
+        {
+            KeybindType.Item => _keybindItemHints,
+            KeybindType.Action => _keybindActionHints,
+            _ => _keybindActionHints
+        };
+
+        return dictionary.TryGetValue(id, out var keybindHint) ? keybindHint : string.Empty;
+    }
+
+    public string GetKeybindHintFormatted(uint id, KeybindType type)
+    {
+        string keybindHint = GetKeybindHint(id, type);
+        keybindHint = keybindHint.ToUpper();
+        keybindHint = keybindHint.Replace("§", "s");      // Shift
+        keybindHint = keybindHint.Replace("\u00a2", "c"); // Control
+        keybindHint = keybindHint.Replace("ª", "a");      // Alt
+        keybindHint = keybindHint.Replace("º", "n");      // Numpad
+        return keybindHint;
+    }
+    
+    public uint StripFirstTwoDigits(uint number)
+    {
+        var numberStr = number.ToString();
+        return numberStr.Length > 2 && uint.TryParse(numberStr.Substring(2), out var result) ? result : 0;
+    }
+
+    public enum KeybindType
+    {
+        Action,
+        Item,
+    }
+}

--- a/DelvCD/Helpers/KeybindHelper.cs
+++ b/DelvCD/Helpers/KeybindHelper.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
@@ -51,21 +51,21 @@ public unsafe class KeybindHelper
     private readonly string?[] _actionBars = ["_ActionBar09", "_ActionBar", "_ActionBar01", "_ActionBar02", "_ActionBar03", "_ActionBar04", "_ActionBar05", "_ActionBar06", "_ActionBar07", "_ActionBar08"];
     
     private void ActionBarUpdateRequested(AddonActionBarX* addon) {
-        var barId = addon->AddonActionBarBase.RaptureHotbarId;
+        byte barId = addon->AddonActionBarBase.RaptureHotbarId;
         if (barId == 9)
         {
             _keybindActionHints.Clear(); // Relies on the game updating action bars in reverse order
             _keybindItemHints.Clear(); // Relies on the game updating action bars in reverse order
         }
 
-        for (var slotIndex = (byte)(addon->AddonActionBarBase.SlotCount - 1); slotIndex < addon->AddonActionBarBase.SlotCount; slotIndex--) {
-            var slot = RaptureHotbarModule.Instance()->GetSlotById(barId, slotIndex);
+        for (byte slotIndex = (byte)(addon->AddonActionBarBase.SlotCount - 1); slotIndex < addon->AddonActionBarBase.SlotCount; slotIndex--) {
+            RaptureHotbarModule.HotbarSlot* slot = RaptureHotbarModule.Instance()->GetSlotById(barId, slotIndex);
             if (slot->CommandType == RaptureHotbarModule.HotbarSlotType.Empty)
             {
                 continue;
             }
 
-            var str = slot->KeybindHintString;
+            string? str = slot->KeybindHintString;
             if (string.IsNullOrWhiteSpace(str)) {
                 continue;
             }
@@ -73,20 +73,20 @@ public unsafe class KeybindHelper
             if (slot->CommandType == RaptureHotbarModule.HotbarSlotType.Item)
             {
                 // For some reason the first 2 digits for items (well or some items) is 10?
-                var itemId = StripFirstTwoDigits(slot->CommandId);
+                uint itemId = StripFirstTwoDigits(slot->CommandId);
                 _keybindItemHints[itemId] = str;
                 continue;
             }
             
-            var actionId = ActionManager.Instance()->GetAdjustedActionId(slot->CommandId);
+            uint actionId = ActionManager.Instance()->GetAdjustedActionId(slot->CommandId);
             _keybindActionHints[actionId] = str;
         }
     }
     
     public void UpdateKeybindHints() {
-        var gameGui = Singletons.Get<IGameGui>();
+        IGameGui gameGui = Singletons.Get<IGameGui>();
 
-        foreach (var addonName in _actionBars) {
+        foreach (string? addonName in _actionBars) {
             string? nameToUse = addonName;
 
             AddonActionBarX* addon = !string.IsNullOrEmpty(nameToUse) 
@@ -101,14 +101,14 @@ public unsafe class KeybindHelper
 
     public string GetKeybindHint(uint id, KeybindType type)
     {
-        var dictionary = type switch
+        Dictionary<uint, string> dictionary = type switch
         {
             KeybindType.Item => _keybindItemHints,
             KeybindType.Action => _keybindActionHints,
             _ => _keybindActionHints
         };
 
-        return dictionary.TryGetValue(id, out var keybindHint) ? keybindHint : string.Empty;
+        return dictionary.TryGetValue(id, out string? keybindHint) ? keybindHint : string.Empty;
     }
 
     public string GetKeybindHintFormatted(uint id, KeybindType type)
@@ -130,8 +130,8 @@ public unsafe class KeybindHelper
     
     public uint StripFirstTwoDigits(uint number)
     {
-        var numberStr = number.ToString();
-        return numberStr.Length > 2 && uint.TryParse(numberStr.Substring(2), out var result) ? result : 0;
+        string numberStr = number.ToString();
+        return numberStr.Length > 2 && uint.TryParse(numberStr.Substring(2), out uint result) ? result : 0;
     }
 
     public enum KeybindType

--- a/DelvCD/Helpers/TextTagFormatter.cs
+++ b/DelvCD/Helpers/TextTagFormatter.cs
@@ -11,7 +11,7 @@ namespace DelvCD.Helpers
 {
     public class TextTagFormatter
     {
-        public static Regex TextTagRegex { get; } = new Regex(@"\[(\w*)(:\w)?\.?(\d+)?\]", RegexOptions.Compiled);
+        public static Regex TextTagRegex { get; } = new Regex(@"\[(\w*)(:\w+)?\.?(\d+)?\]", RegexOptions.Compiled);
 
         private static Dictionary<Type, Dictionary<string, FieldInfo>> _fieldsMap = new();
         
@@ -79,7 +79,17 @@ namespace DelvCD.Helpers
                         int.TryParse(m.Groups[3].Value, out int trim) &&
                         trim < value.Length)
                     {
-                        value = propValue?.ToString().AsSpan(0, trim).ToString();
+                        value = value.AsSpan(0, trim).ToString();
+                    }
+
+                    if (value != null)
+                    {
+                        value = m.Groups[2].Value switch
+                        {
+                            ":upper" => value.ToUpper(),
+                            ":lower" => value.ToLower(),
+                            _ => value
+                        };
                     }
                 }
             }

--- a/DelvCD/Helpers/Utils.cs
+++ b/DelvCD/Helpers/Utils.cs
@@ -108,7 +108,7 @@ namespace DelvCD.Helpers
                     "[value:k.1]  =>       1.2k\n\n" +
                     "[name]                   =>    Firstname Lastname\n" +
                     "[name:upper]       =>    FIRSTNAME LASTNAME\n" +
-                    "[name:lower]        =>    firstname lastname\n" +
+                    "[name:lower]       =>    firstname lastname\n" +
                     "[name_first.5]    =>    First\n" +
                     "[name_last.1]     =>    L";
         }

--- a/DelvCD/Helpers/Utils.cs
+++ b/DelvCD/Helpers/Utils.cs
@@ -107,6 +107,8 @@ namespace DelvCD.Helpers
                     "[value:t]       =>     20:34\n" +
                     "[value:k.1]  =>       1.2k\n\n" +
                     "[name]                   =>    Firstname Lastname\n" +
+                    "[name:upper]       =>    FIRSTNAME LASTNAME\n" +
+                    "[name:lower]        =>    firstname lastname\n" +
                     "[name_first.5]    =>    First\n" +
                     "[name_last.1]     =>    L";
         }

--- a/DelvCD/Plugin.cs
+++ b/DelvCD/Plugin.cs
@@ -87,6 +87,7 @@ namespace DelvCD
             Singletons.Register(new ActionHelpers());
             Singletons.Register(new StatusHelpers());
             Singletons.Register(new ClipRectsHelper());
+            Singletons.Register(new KeybindHelper());
 
             // Load Icon
             Plugin.IconTexture = LoadIconTexture(textureProvider);

--- a/DelvCD/Plugin.cs
+++ b/DelvCD/Plugin.cs
@@ -108,6 +108,9 @@ namespace DelvCD
 
             // Start the plugin
             Singletons.Register(new PluginManager(clientState, commandManager, pluginInterface, config));
+            
+            // Update Keybind Hints
+            Singletons.Get<KeybindHelper>().UpdateKeybindHints();
         }
 
         private static IDalamudTextureWrap? LoadIconTexture(ITextureProvider textureProvider)

--- a/DelvCD/PluginManager.cs
+++ b/DelvCD/PluginManager.cs
@@ -179,6 +179,7 @@ namespace DelvCD
                 // Don't modify order
                 PluginInterface.UiBuilder.Draw -= Draw;
                 PluginInterface.UiBuilder.OpenConfigUi -= OpenConfigUi;
+                ClientState.Login -= OnLogin;
                 ClientState.Logout -= OnLogout;
                 CommandManager.RemoveHandler("/delvcd");
                 CommandManager.RemoveHandler("/dcd");

--- a/DelvCD/PluginManager.cs
+++ b/DelvCD/PluginManager.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Numerics;
 using Dalamud.Game.Command;
 using Dalamud.Interface.Utility;
@@ -72,6 +72,7 @@ namespace DelvCD
             );
 
             ClientState.Logout += OnLogout;
+            ClientState.Logout += OnLogin;
             PluginInterface.UiBuilder.OpenConfigUi += OpenConfigUi;
             PluginInterface.UiBuilder.Draw += Draw;
         }
@@ -141,6 +142,11 @@ namespace DelvCD
             {
                 ConfigRoot.PushConfig(Config);
             }
+        }
+
+        private void OnLogin()
+        {
+            Singletons.Get<KeybindHelper>().UpdateKeybindHints();
         }
 
         private void OnLogout(int type, int code)

--- a/DelvCD/PluginManager.cs
+++ b/DelvCD/PluginManager.cs
@@ -72,7 +72,7 @@ namespace DelvCD
             );
 
             ClientState.Logout += OnLogout;
-            ClientState.Logout += OnLogin;
+            ClientState.Login += OnLogin;
             PluginInterface.UiBuilder.OpenConfigUi += OpenConfigUi;
             PluginInterface.UiBuilder.Draw += Draw;
         }


### PR DESCRIPTION
~~Don't merge yet, I need help with 2 tiny things.~~

~~1. These keybinds currently only show up when a cooldown or item is on cooldown.~~ Was a skill issue
~~2. I'd like to move `keybindHelper.UpdateKeybindHints();` to a better place as per my comment:~~ Changed with the new jobchange event + on login/plugin start
~~// TODO: Needs to be moved to some place/event that only gets triggered on either job swap or when someone updates their hotbar~~
~~// AgentUpdateFlags ActionBarUpdate is no good because that will trigger by using actions as well apparently~~

If these 2 things are solved then it'd be good to go/merge. Hope anyone can assist me on this.

Things to think about:
- ~~Do we want a generic toUpper and toLower method (different people prefer different visual styles, I highly prefer sQ for Shift Q for example but some might want SQ).~~ Added
- ~~Any replacements I missed for the formatted versions?~~ Haven't found modifiers I have missed.

Edit: For some reason I can't assign reviewers, @Tischel @WesBosch