### PR TITLE
Fix AssemblyFileDir, add .otf support

### DIFF
--- a/DelvCD/Config/FontConfig.cs
+++ b/DelvCD/Config/FontConfig.cs
@@ -168,6 +168,10 @@ namespace DelvCD.Config
 
         private void AddFont(int fontIndex, int size)
         {
+            if (_fonts.Length == 0)
+            {
+                return;
+            }
             FontData newFont = new FontData(_fonts[fontIndex], size + 1, _chinese, _korean);
             AddFont(newFont);
         }

--- a/DelvCD/Helpers/FontsManager.cs
+++ b/DelvCD/Helpers/FontsManager.cs
@@ -1,6 +1,7 @@
 ﻿﻿using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Reflection;
 using Dalamud.Interface;
 using Dalamud.Interface.ManagedFontAtlas;
@@ -75,8 +76,22 @@ namespace DelvCD.Helpers
 
             foreach (var font in fontData)
             {
-                var fontPath = $"{fontDir}{font.Name}.ttf";
-                if (!File.Exists(fontPath))
+                // Check for both .ttf and .otf files
+                var fontPathTtf = $"{fontDir}{font.Name}.ttf";
+                var fontPathOtf = $"{fontDir}{font.Name}.otf";
+                var fontPath = string.Empty;
+
+                if (File.Exists(fontPathTtf))
+                {
+                    fontPath = fontPathTtf;
+                }
+                else if (File.Exists(fontPathOtf))
+                {
+                    fontPath = fontPathOtf;
+                }
+
+                // If neither file exists, continue to the next font
+                if (string.IsNullOrEmpty(fontPath))
                 {
                     continue;
                 }
@@ -223,7 +238,10 @@ namespace DelvCD.Helpers
             string[] pluginFonts;
             try
             {
-                pluginFonts = Directory.GetFiles(pluginFontPath, "*.ttf");
+                string[] ttfFonts = Directory.GetFiles(pluginFontPath, "*.ttf");
+                string[] otfFonts = Directory.GetFiles(pluginFontPath, "*.otf");
+
+                pluginFonts = ttfFonts.Concat(otfFonts).Order().ToArray();
             }
             catch
             {
@@ -253,7 +271,7 @@ namespace DelvCD.Helpers
 
         public static string GetPluginFontPath()
         {
-            string? path = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
+            string? path = Path.GetDirectoryName(Plugin.AssemblyFileDir);
 
             if (path is not null)
             {
@@ -278,7 +296,9 @@ namespace DelvCD.Helpers
             string[] fonts;
             try
             {
-                fonts = Directory.GetFiles(path, "*.ttf");
+                string[] ttfFonts = Directory.GetFiles(path, "*.ttf");
+                string[] otfFonts = Directory.GetFiles(path, "*.otf");
+                fonts = ttfFonts.Concat(otfFonts).Order().ToArray();
             }
             catch
             {
@@ -289,7 +309,8 @@ namespace DelvCD.Helpers
             {
                 fonts[i] = fonts[i]
                     .Replace(path, string.Empty)
-                    .Replace(".ttf", string.Empty, StringComparison.OrdinalIgnoreCase);
+                    .Replace(".ttf", string.Empty, StringComparison.OrdinalIgnoreCase)
+                    .Replace(".otf", string.Empty, StringComparison.OrdinalIgnoreCase);
             }
 
             return fonts;

--- a/DelvCD/Plugin.cs
+++ b/DelvCD/Plugin.cs
@@ -52,7 +52,15 @@ namespace DelvCD
             Plugin.Version = Assembly.GetExecutingAssembly().GetName().Version?.ToString() ?? Plugin.Version;
             Plugin.ConfigFileDir = pluginInterface.GetPluginConfigDirectory();
             Plugin.ConfigFilePath = Path.Combine(pluginInterface.GetPluginConfigDirectory(), Plugin.ConfigFileName);
-            Plugin.AssemblyFileDir = pluginInterface.AssemblyLocation.DirectoryName ?? "";
+            
+            if (pluginInterface.AssemblyLocation.DirectoryName != null)
+            {
+                AssemblyFileDir = pluginInterface.AssemblyLocation.DirectoryName + "\\";
+            }
+            else
+            {
+                AssemblyFileDir = Assembly.GetExecutingAssembly().Location;
+            }
 
             ConfigHelpers.CheckVersion();
 


### PR DESCRIPTION
Fixes #35. This was caused by the DelvCD fonts folder not being created on first plugin use as well as prevent AddFont from trying a font that did not exist causing ImGui to break.

Also added support for .otf, does not break existing fonts, I even tried adding a .otf with a font of the same name, no issues.