### PR TITLE
Fix config opening shrunken topleft corner

### DIFF
--- a/DelvCD/PluginManager.cs
+++ b/DelvCD/PluginManager.cs
@@ -49,7 +49,7 @@ namespace DelvCD
             PluginInterface = pluginInterface;
             Config = config;
 
-            ConfigRoot = new ConfigWindow("ConfigRoot", ImGui.GetMainViewport().Size / 2, _configSize);
+            ConfigRoot = new ConfigWindow("DelvCD ConfigRoot", ImGui.GetMainViewport().Size / 2, _configSize);
             WindowSystem = new WindowSystem("DelvCD");
             WindowSystem.AddWindow(ConfigRoot);
 

--- a/DelvCD/Windows/ConfigWindow.cs
+++ b/DelvCD/Windows/ConfigWindow.cs
@@ -17,8 +17,10 @@ namespace DelvCD.Windows
 
         private bool _back = false;
         private bool _home = false;
+        private bool _firstOpen = true;
         private string _name = string.Empty;
         private Vector2 _windowSize;
+        private Vector2 _windowPos;
         private Stack<IConfigurable> _configStack;
         private float _scale => ImGuiHelpers.GlobalScale;
 
@@ -39,6 +41,7 @@ namespace DelvCD.Windows
             };
 
             _windowSize = size;
+            _windowPos = position;
             _configStack = new Stack<IConfigurable>();
         }
 
@@ -46,6 +49,7 @@ namespace DelvCD.Windows
         {
             _configStack.Push(configItem);
             _name = configItem.Name;
+            _firstOpen = true;
             IsOpen = true;
         }
 
@@ -64,7 +68,12 @@ namespace DelvCD.Windows
             if (_configStack.Any())
             {
                 WindowName = GetWindowTitle();
-                ImGui.SetNextWindowSize(_windowSize);
+                
+                if (_firstOpen)
+                {
+                    ImGui.SetNextWindowSize(_windowSize, ImGuiCond.Always);
+                    ImGui.SetNextWindowPos(_windowPos, ImGuiCond.Always);
+                }
             }
         }
 
@@ -109,6 +118,7 @@ namespace DelvCD.Windows
 
             Position = ImGui.GetWindowPos();
             _windowSize = ImGui.GetWindowSize();
+            _firstOpen = false;
         }
 
         private void DrawNavBar(IConfigPage? openPage, Vector2 size, float padX)


### PR DESCRIPTION
This fixes the issue that the configuration window opens on 0,0 with an invalid height in the top left of the corner like I showed on Discord.