### PR TITLE
Fix Dancer next step from being out of bounds during Technical Step

### DIFF
--- a/DelvCD/Config/JobGauges/DancerJobGauge.cs
+++ b/DelvCD/Config/JobGauges/DancerJobGauge.cs
@@ -71,6 +71,8 @@ namespace DelvCD.Config.JobGauges
             _dataSource.Esprit = gauge.Esprit;
             _dataSource.Dancing = gauge.IsDancing;
             _dataSource.Completed_Steps = gauge.CompletedSteps;
+            
+            int nextStep = gauge is { IsDancing: true, CompletedSteps: < 4 } ? (int)gauge.NextStep : 15998;
 
             if (preview) { return true; }
 
@@ -78,7 +80,7 @@ namespace DelvCD.Config.JobGauges
                 EvaluateCondition(0, _dataSource.Feather_Stacks) &&
                 EvaluateCondition(1, _dataSource.Esprit) &&
                 EvaluateCondition(2, _dataSource.Dancing) &&
-                EvaluateCondition(3, (int)gauge.NextStep - (int)DNCStep.None) &&
+                EvaluateCondition(3, nextStep - (int)DNCStep.None) &&
                 EvaluateStepCondition(gauge, 0) &&
                 EvaluateStepCondition(gauge, 1) &&
                 EvaluateStepCondition(gauge, 2) &&


### PR DESCRIPTION
Fixes #70, Clientstructs DancerGauge.NextStep goes out of bounds when you have completed all 4 steps for Technical Step but before you hit the finish button, resulting in your log being spammed by Index was outside the bounds of the array.
This fix simply just sets the nextStep to 15998 manually since that equals not dancing anyway.